### PR TITLE
Add lambda layer to workflow API and MIE Custom

### DIFF
--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -1195,6 +1195,7 @@ Resources:
         HistoryTableName: !Ref HistoryTable
         SystemTableName: !Ref SystemTable
         SqsQueueArn: !GetAtt StageExecutionQueue.Arn
+        MediaInsightsEnginePython37Layer: !Ref MediaInsightsEnginePython37Layer
         CompleteStageLambdaArn:
           Fn::GetAtt:
             - CompleteStageLambda

--- a/source/workflowapi/external_resources.json
+++ b/source/workflowapi/external_resources.json
@@ -75,6 +75,10 @@
     "SqsQueueArn": {
       "Type": "String",
       "Description": "Arn of the MIE workflow queue"
+    },
+    "MediaInsightsEnginePython37Layer": {
+      "Type": "String",
+      "Description": "Arn of the MIE Python 3.7 lambda layer"
     }
   },
   "Resources": {
@@ -217,6 +221,11 @@
                 }
             }
         },
+        "Layers": [
+          {
+            "Ref": "MediaInsightsEnginePython37Layer"
+            }
+          ],
         "CodeUri": {"Bucket":  {"Ref": "DeploymentPackageBucket"}, "Key":  {"Ref": "DeploymentPackageKey"}}
       }
     },
@@ -271,8 +280,14 @@
                 }
             }
         },
+        "Layers": [
+          {
+            "Ref": "MediaInsightsEnginePython37Layer"
+            }
+          ],
         "CodeUri": {"Bucket":  {"Ref": "DeploymentPackageBucket"}, "Key":  {"Ref": "DeploymentPackageKey"}}
-      }
+        }
+      
     },
     "RestAPI": {
       "Properties": {

--- a/source/workflowapi/requirements.txt
+++ b/source/workflowapi/requirements.txt
@@ -1,7 +1,7 @@
-chalice==1.7.0
+#chalice==1.7.0
 docopt==0.6.2
-aws_sam_translator==1.8.0
+#aws_sam_translator==1.8.0
 #botocore==1.10.84
 jsonschema==2.6.0
 #boto3==1.7.43
-../../source/lib/MediaInsightsEngineLambdaHelper/dist/Media_Insights_Engine_Lambda_Helper-0.0.3-py3-none-any.whl
+#../lib/MediaInsightsEngineLambdaHelper/dist/Media_Insights_Engine_Lambda_Helper-0.0.3-py3-none-any.whl


### PR DESCRIPTION

*Description of changes:*

The Workflow API lambda functions were packaging the lambda layer package from the local build rather than using the Layers feature in lambda.  This makes it so the lambda package too large to be editable in the  lambda console IDE. Makes debugging the console very difficult.

Added lambda layer to the lambda resource definition in cloud formation and removed boto3, chalice, and botocore from the lambda package.

To build the workflowapi lambda packages locally, follow the build script:

```
# Create and activate a temporary Python environment for this script.
echo "------------------------------------------------------------------------------"
echo "Creating a temporary Python virtualenv for this script"
echo "------------------------------------------------------------------------------"
python -c "import os; print (os.getenv('VIRTUAL_ENV'))" | grep -q None
if [ $? -ne 0 ]; then
    echo "ERROR: Do not run this script inside Virtualenv. Type \`deactivate\` and run again.";
    exit 1;
fi
command -v python3
if [ $? -ne 0 ]; then
    echo "ERROR: install Python3 before running this script"
    exit 1
fi
VENV=$(mktemp -d)
python3 -m venv "$VENV"
source "$VENV"/bin/activate
pip install --quiet boto3 chalice docopt pyyaml jsonschema
export PYTHONPATH="$PYTHONPATH:$source_dir/lib/MediaInsightsEngineLambdaHelper/"
echo "PYTHONPATH=$PYTHONPATH"
if [ $? -ne 0 ]; then
    echo "ERROR: Failed to install required Python libraries."
    exit 1
fi
echo "Building Workflow Lambda function"
cd "$source_dir/workflowapi" || exit 1
[ -e dist ] && rm -r dist
mkdir -p dist
if ! [ -x "$(command -v chalice)" ]; then
  echo 'Chalice is not installed. It is required for this solution. Exiting.'
  exit 1
fi
echo "running chalice..."
chalice package --merge-template external_resources.json dist
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
