### PR TITLE
Include mov in the inpput datatype mapping for

### DIFF
--- a/source/workflowapi/app.py
+++ b/source/workflowapi/app.py
@@ -1871,7 +1871,7 @@ def create_workflow_execution(trigger, workflow_execution):
                 asset_id = asset_creation["AssetId"]
         else:
             # TODO: Probably just accept the media type as input parameter
-            data_type_mapping = {"mp4": "Video", "mp3": "Audio", "txt": "Text", "json": "Text", "ogg": "Video"}
+            data_type_mapping = {"mov":"Video", "mp4": "Video", "mp3": "Audio", "txt": "Text", "json": "Text", "ogg": "Video"}
             try:
                 input = workflow_execution["Input"]["AssetId"]
             except KeyError as e:


### PR DESCRIPTION
500 error from /workflow/execution API when rerunning a workflow on and existing asset that is .mov.  

In the caption edting page of the UI, the 500 error is not caught, so the edits are saved but the workflow is not rerun.  There is no indication to the end user that there is an error.

*Description of changes:*

Added .mov to the Video type asset mapping in the workflow API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
